### PR TITLE
on athena ready deferred notify triggering, now with deferred list

### DIFF
--- a/public/button3.html
+++ b/public/button3.html
@@ -49,8 +49,6 @@
 
   <div id="container">
     <button data-athena="ui:Button:Next">Next</button>
-    <button data-athena="ui:Button:Next">Next</button>
-    <button data-athena="ui:Button:Next">Next</button>
   </div>
 
 

--- a/public/defer.html
+++ b/public/defer.html
@@ -92,6 +92,13 @@
         </span>
       </fieldset>
     </form>
+    
+    
+    <span class="hidden doClassesWork" id="revealContent12" data-athena="ui:Container">
+      Do classes work for revealing containers?
+    </span>
+    
+    
   </div>
 </body>
 </html>

--- a/public/defer.html
+++ b/public/defer.html
@@ -54,18 +54,21 @@
       
       <fieldset>
         <legend>Radio Buttons -- not in List</legend>
-          <label><input type="radio" name="myRadioBtn2" value="on6" aria-controls="revealContent6" data-athena="ui:Button:Radio">6</label>
-          <label><input type="radio" name="myRadioBtn2" value="on7" aria-controls="revealContent7" data-athena="ui:Button:Radio">7</label>
-          <label><input type="radio" name="myRadioBtn2" value="on8" aria-controls="revealContent8" data-athena="ui:Button:Radio">8</label>
-          <span class="hidden" id="revealContent8" data-athena="ui:Container">
-            Extra content for 8.
-          </span>
-          <span class="hidden" id="revealContent6" data-athena="ui:Container">
-            Extra content for 6.
-          </span>
-          <span class="hidden" id="revealContent7" data-athena="ui:Container">
-            Extra content for 7.
-          </span>
+        <label><input type="radio" name="myRadioBtn2" value="on6" aria-controls="revealContent6" data-athena="ui:Button:Radio">6</label>
+        <span class="hidden" id="revealContent6" data-athena="ui:Container">
+          Extra content for 6.
+        </span>
+
+        <label><input type="radio" name="myRadioBtn2" value="on7" aria-controls="revealContent7" data-athena="ui:Button:Radio">7</label>
+        <span class="hidden" id="revealContent7" data-athena="ui:Container">
+          Extra content for 7.
+        </span>
+
+        <label><input type="radio" name="myRadioBtn2" value="on8" aria-controls="revealContent8" data-athena="ui:Button:Radio">8</label>
+
+        <span class="hidden" id="revealContent8" data-athena="ui:Container">
+          Extra content for 8.
+        </span>
 
       </fieldset>
       
@@ -77,6 +80,7 @@
           <option value="10" aria-controls="revealContent10">ten</option>
           <option value="11" aria-controls="revealContent11">eleven</option>                    
         </select>
+
         <span class="hidden" id="revealContent9" data-athena="ui:Container">
           Extra content for 9.
         </span>

--- a/public/scripts/libraries/athena-0.0.1.js
+++ b/public/scripts/libraries/athena-0.0.1.js
@@ -23,10 +23,10 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-$( 'body' ).on( 'athena-executed', function( event, control ) {
-  console.log( $( this ).is( event.target ) );
-  console.log( 'control', control );
-} );
+// $( 'body' ).on( 'athena-executed', function( event, control ) {
+//   console.log( $( this ).is( event.target ) );
+//   console.log( 'control', control );
+// } );
 
 $( 'body' ).on( 'athena-ready', function( event, executed ) {
   console.log('YEAAAAA!!!!!!!', executed );
@@ -61,7 +61,8 @@ Athena = function( settings ) {
       var packages = {},
       on = $.fn.on,
       off = $.fn.off,
-      trigger = $.fn.trigger;
+      trigger = $.fn.trigger,
+      $deferred = $.Deferred();
 
     /**
      * Queues a control for execution with selected node.
@@ -234,16 +235,12 @@ Athena = function( settings ) {
           $controls.each( function( index, control ) {
             execute( $( control ) );
             numberOfControls -= 1;
-            console.log(numberOfControls);
-            if( numberOfControls === 1 ) {
+            //console.log(numberOfControls);
+            if( numberOfControls === 0 ) {
               $this.trigger( 'athena-ready', [ $this ] );
+              $deferred.resolve();
             }
           } );
-          
-          _.log("YOJIMG", "Athena executing", module);
-          if ( $this.is("body") ) {
-            $this.trigger("athena-ready");
-          }
           
         } );
       } catch( error ) {}
@@ -273,56 +270,78 @@ Athena = function( settings ) {
        return trigger.apply( $this, [event, parameters] );
     };
 
-     /**
-      * Notifies all observers of an event
-      * @method notify
-      * @public
-      * @param {String} A string containing a JavaScript event type, such as click or submit.
-      * @param {Array} Additional parameters to pass along to the event handler.
-      */
-     $.fn.notify = function( event, parameters ) {
-       var $this = $( this );
-       if( $this.data( '$observers' ) ) {
-         $this.data( '$observers' ).trigger( event, parameters );
-       }
-     };
+    /**
+     * Notifies all observers of an event
+     * @method notify
+     * @public
+     * @param {String} A string containing a JavaScript event type, such as click or submit.
+     * @param {Array} Additional parameters to pass along to the event handler.
+     */
+    $.fn.Xnotify = function( event, parameters ) {
+      var $this = $( this ),
+        $observers = $this.data( "$observers" );
 
-     /**
-      * Adds an observer
-      * @method observe
-      * @public
-      * @param {Array} $observer A jQuery collection of of observers.
-      */
-     $.fn.observe = function( $observer ) {
-       var $this = $( this );
-       if( $this.data( '$observers' ) ) {
-         $this.data( '$observers' ).add( $observer );
-       } else {
-         $this.data( '$observers', $observer );
-       }
-     };
+      if( $observers && $observers.length ) {
+        $this.data( '$observers' ).trigger( event, parameters );
+      }
+    
+    };
 
-     /**
-      * Removes an unobserve
-      * @method unobserve
-      * @public
-      * @param {Array} $observer A jQuery collection.
-      */
-     $.fn.unobserve = function( $observer ) {
-       var $this = $( this ),
-         $observers;
+    $.fn.notify = function( event, parameters ) {
+      var $this = $( this ),
+        $observerData = $this.data( "$observers" );
 
-       $observers = $this.data( '$observers' );
+      if ( $observerData && $observerData.length ) {
+        
+        $deferred.done( function () {
+          _.log("Deferred.done", $observerData);
+          $observerData.trigger( event, parameters );
+        });
 
-       if( $observers ){
-         $observers = $( _.reject( $observers, function( item, index ) {
-           return $observer.is( item );
-         } ) );
-         $this.data( '$observers', $observers );
-       }
-       return $this;
+      }
+    
+    };
 
-     };
+    /**
+     * Adds an observer
+     * @method observe
+     * @public
+     * @param {Array} $observer A jQuery collection of observers.
+     */
+    $.fn.observe = function( $observer ) {
+      var $this = $( this ),
+        $observerData = $this.data( '$observers' );
+
+      if ( $observerData && $observerData.length ) {
+        $this.data( '$observers' , $observerData.add( $observer ) );
+      } else {
+        $this.data( '$observers', $observer );
+      }
+
+    };
+
+    /**
+     * Removes an observer
+     * @method unobserve
+     * @public
+     * @param {Array} $observer A jQuery collection.
+     */
+    $.fn.unobserve = function( $observer ) {
+      var $this = $( this ),
+        $observers;
+
+      $observers = $this.data( '$observers' );
+
+      if( $observers ){
+        $observers = $( _.reject( $observers, function( item, index ) {
+          return $observer.is( item );
+        } ) );
+        $this.data( '$observers', $observers );
+      }
+
+      return $this;
+
+    };
 
   } ( jQuery ) );
 

--- a/public/scripts/libraries/athena-0.0.1.js
+++ b/public/scripts/libraries/athena-0.0.1.js
@@ -160,7 +160,7 @@ Athena = function( settings ) {
 
     /**
      * Parses the DOM starting with selected element, requires necessary JS Files, and instantiates Athena controls. 
-     * @method getControl
+     * @method execute
      * @public
      * @param {String} id The id of returned control.
      */
@@ -279,16 +279,6 @@ Athena = function( settings ) {
      * @param {String} A string containing a JavaScript event type, such as click or submit.
      * @param {Array} Additional parameters to pass along to the event handler.
      */
-    $.fn.Xnotify = function( event, parameters ) {
-      var $this = $( this ),
-        $observers = $this.data( "$observers" );
-
-      if( $observers && $observers.length ) {
-        $this.data( '$observers' ).trigger( event, parameters );
-      }
-    
-    };
-
     $.fn.notify = function( event, parameters ) {
       var $this = $( this ),
         $observerData = $this.data( "$observers" );
@@ -319,7 +309,15 @@ Athena = function( settings ) {
         $this.data( '$observers', $observer );
       }
       
-      $this.data("$deferred", _.last($deferred) );
+      // Don't overwrite any existing Deferred object ??
+      // TODO: push Deferred onto an array?
+      if ( $this.data("$deferred") ) {
+        // tbd
+      }
+      else {
+        $this.data("$deferred", _.last($deferred) );        
+      }
+
 
     };
 

--- a/public/scripts/libraries/athena-0.0.1.js
+++ b/public/scripts/libraries/athena-0.0.1.js
@@ -62,7 +62,8 @@ Athena = function( settings ) {
       on = $.fn.on,
       off = $.fn.off,
       trigger = $.fn.trigger,
-      $deferred = $.Deferred();
+      $deferred = [$.Deferred()];
+      
 
     /**
      * Queues a control for execution with selected node.
@@ -238,7 +239,8 @@ Athena = function( settings ) {
             //console.log(numberOfControls);
             if( numberOfControls === 0 ) {
               $this.trigger( 'athena-ready', [ $this ] );
-              $deferred.resolve();
+              _.last($deferred).resolve();
+              $deferred.push( $.Deferred() );
             }
           } );
           
@@ -293,8 +295,7 @@ Athena = function( settings ) {
 
       if ( $observerData && $observerData.length ) {
         
-        $deferred.done( function () {
-          _.log("Deferred.done", $observerData);
+        $this.data("$deferred").done( function () {
           $observerData.trigger( event, parameters );
         });
 
@@ -317,6 +318,8 @@ Athena = function( settings ) {
       } else {
         $this.data( '$observers', $observer );
       }
+      
+      $this.data("$deferred", _.last($deferred) );
 
     };
 

--- a/public/scripts/packages/ui/Button/MultiSwitch.js
+++ b/public/scripts/packages/ui/Button/MultiSwitch.js
@@ -1,0 +1,71 @@
+var Class = require( '/scripts/libraries/ptclass' ),
+  Switch = require( 'ui/Button/Switch' ),
+  MultiSwitch;
+
+/**
+ * Representation of a stateful button element
+ * @class MultiSwitch
+ * @constructor
+ * @extends Switch
+ * @param {HTMLElement} element The HTML element surrounded by the control
+ * @param {Object} settings Configuration properties for this instance
+ */
+MultiSwitch = Class.create( Switch,  ( function () {
+
+   // RETURN METHODS OBJECT
+   return {
+     /**
+      * PTClass constructor 
+      * @method initialize
+      * @public
+      * @param {Object} $super Pointer to superclass constructor
+      * @param {Object} $element JQuery object for the element wrapped by the component
+      * @param {Object} settings Configuration settings
+      */    
+     initialize: function ( $super, $element, settings ) {
+
+       // PRIVATE INSTANCE PROPERTIES
+
+       /**
+        * Default configuration values
+        * @property defaults
+        * @type Object
+        * @private
+        * @final
+        */
+       var defaults = {
+         states: [
+          {
+            state: "OFF",
+            label: "off",
+            className: "athena-switch-off"
+          }, 
+          {
+            state: "ON",
+            label: "on",
+            className: "athena-switch-on"
+          },
+          {
+            state: "ON2",
+            label: "on2",
+            className: "athena-switch-on2"
+          }
+          
+         ]
+       };
+       
+       // MIX THE DEFAULTS INTO THE SETTINGS VALUES
+       _.defaults( settings, defaults );
+   
+       // CALL THE PARENT'S CONSTRUCTOR
+       $super( $element, settings );
+       
+     }
+  };
+  
+}() ));
+
+//Export to CommonJS Loader
+if( module && module.exports ) {
+  module.exports = MultiSwitch;
+}

--- a/public/scripts/packages/ui/Button/Radio.js
+++ b/public/scripts/packages/ui/Button/Radio.js
@@ -3,11 +3,12 @@ var Class = require( '/scripts/libraries/ptclass' ),
   RadioButton;
   
 
+
 /**
  * Toggles the display of related content to a change event from a grouping of radio buttons.
  * @class RadioButton
  * @constructor
- * @extends Button
+ * @extends FormSelect
  * @require ptclass, Button
  */
 RadioButton = Class.create( FormSelect,  ( function () {

--- a/public/scripts/packages/ui/Button/Switch.js
+++ b/public/scripts/packages/ui/Button/Switch.js
@@ -1,0 +1,121 @@
+var Class = require( '/scripts/libraries/ptclass' ),
+  Button = require( 'ui/Button' ),
+  Switch;
+
+/**
+ * Representation of a stateful button element
+ * @class Switch
+ * @constructor
+ * @extends Button
+ * @param {HTMLElement} element The HTML element surrounded by the control
+ * @param {Object} settings Configuration properties for this instance
+ */
+Switch = Class.create( Button,  ( function () {
+
+   // RETURN METHODS OBJECT
+   return {
+     
+     /**
+      * PTClass constructor 
+      * @method initialize
+      * @public
+      * @param {Object} $super Pointer to superclass constructor
+      * @param {Object} $element JQuery object for the element wrapped by the component
+      * @param {Object} settings Configuration settings
+      */    
+     initialize: function ( $super, $element, settings ) {
+
+       // PRIVATE INSTANCE PROPERTIES
+
+       /**
+        * Instance of Switch
+        * @property Switch
+        * @type Object
+        * @private
+        */     
+       var Switch = this,
+
+       /**
+        * Default configuration values
+        * @property defaults
+        * @type Object
+        * @private
+        * @final
+        */
+       defaults = {
+         action: 'change',
+         states: [
+          {
+            state: "OFF",
+            label: "off",
+            className: "athena-switch-off"
+          }, 
+          {
+            state: "ON",
+            label: "on",
+            className: "athena-switch-on"
+          }
+         ]
+       },
+       /**
+        * List of states for the switch
+        * @property states
+        * @type Array
+        * @private
+        */
+       states,
+       i = 0,
+       statesLen,
+       lastState,
+       activeState;
+       
+       // MIX THE DEFAULTS INTO THE SETTINGS VALUES
+       _.defaults( settings, defaults );
+   
+       // CALL THE PARENT'S CONSTRUCTOR
+       $super( $element, settings );
+       
+       states = settings.states;
+       statesLen = states.length;
+       activeState = states[i];
+       
+       /**
+        * Sets the state of the switch 
+        * @method toggleState
+        * @public
+        * @return {Object} the Switch instance (for chaining)
+        */       
+       Switch.toggleState = function () {
+         
+         lastState = activeState;
+         
+         // Increment counter
+         ++i;
+
+         // Reset the counter if at the end of the array
+         if ( i === statesLen ) {
+           i = 0;
+         }
+         
+         activeState = states[i];
+         
+         $element.removeClass(lastState.className).addClass(activeState.className);
+         
+         _.log("Switch", "state", activeState);
+         return Switch;
+       };
+              
+       $element.on( settings.on, function ( event ) {
+         event.preventDefault();
+         Switch.toggleState();
+       });
+       
+     }
+  };
+  
+}() ));
+
+//Export to CommonJS Loader
+if( module && module.exports ) {
+  module.exports = Switch;
+}

--- a/public/scripts/packages/ui/Container/Switch.js
+++ b/public/scripts/packages/ui/Container/Switch.js
@@ -1,0 +1,121 @@
+var Class = require( '/scripts/libraries/ptclass' ),
+  Container = require( 'ui/Container' ),
+  Switch;
+
+/**
+ * Representation of a stateful button element
+ * @class Switch
+ * @constructor
+ * @extends Container
+ * @param {HTMLElement} element The HTML element surrounded by the control
+ * @param {Object} settings Configuration properties for this instance
+ */
+Switch = Class.create( Container,  ( function () {
+
+   // RETURN METHODS OBJECT
+   return {
+     
+     /**
+      * PTClass constructor 
+      * @method initialize
+      * @public
+      * @param {Object} $super Pointer to superclass constructor
+      * @param {Object} $element JQuery object for the element wrapped by the component
+      * @param {Object} settings Configuration settings
+      */    
+     initialize: function ( $super, $element, settings ) {
+
+       // PRIVATE INSTANCE PROPERTIES
+
+       /**
+        * Instance of Switch
+        * @property Switch
+        * @type Object
+        * @private
+        */     
+       var Switch = this,
+
+       /**
+        * Default configuration values
+        * @property defaults
+        * @type Object
+        * @private
+        * @final
+        */
+       defaults = {
+         on: 'select change',
+         states: [
+          {
+            state: "OFF",
+            label: "off",
+            className: "athena-switch-off"
+          }, 
+          {
+            state: "ON",
+            label: "on",
+            className: "athena-switch-on"
+          }
+         ]
+       },
+       /**
+        * List of states for the switch
+        * @property states
+        * @type Array
+        * @private
+        */
+       states,
+       i = 0,
+       statesLen,
+       lastState,
+       activeState;
+       
+       // MIX THE DEFAULTS INTO THE SETTINGS VALUES
+       _.defaults( settings, defaults );
+   
+       // CALL THE PARENT'S CONSTRUCTOR
+       $super( $element, settings );
+       
+       states = settings.states;
+       statesLen = states.length;
+       activeState = states[i];
+       
+       /**
+        * Sets the state of the switch 
+        * @method toggleState
+        * @public
+        * @return {Object} the Switch instance (for chaining)
+        */       
+       Switch.toggleState = function () {
+         
+         lastState = activeState;
+         
+         // Increment counter
+         ++i;
+
+         // Reset the counter if at the end of the array
+         if ( i === statesLen ) {
+           i = 0;
+         }
+         
+         activeState = states[i];
+         
+         $element.removeClass(lastState.className).addClass(activeState.className);
+         
+         _.log("Switch", "state", activeState);
+         return Switch;
+       };
+              
+       $element.on( settings.on, function ( event ) {
+         event.preventDefault();
+         Switch.toggleState();
+       });
+       
+     }
+  };
+  
+}() ));
+
+//Export to CommonJS Loader
+if( module && module.exports ) {
+  module.exports = Switch;
+}

--- a/public/scripts/packages/ui/Container/Switch.js
+++ b/public/scripts/packages/ui/Container/Switch.js
@@ -12,107 +12,99 @@ var Class = require( '/scripts/libraries/ptclass' ),
  */
 Switch = Class.create( Container,  ( function () {
 
-   // RETURN METHODS OBJECT
-   return {
+  var DISABLED = "disabled";
+
+  // RETURN METHODS OBJECT
+  return {
+    /**
+     * PTClass constructor 
+     * @method initialize
+     * @public
+     * @param {Object} $super Pointer to superclass constructor
+     * @param {Object} $element JQuery object for the element wrapped by the component
+     * @param {Object} settings Configuration settings
+     */    
+    initialize: function ( $super, $element, settings ) {
+
+      // PRIVATE INSTANCE PROPERTIES
+
+      /**
+       * Instance of Switch
+       * @property Switch
+       * @type Object
+       * @private
+       */     
+      var Switch = this,
+
+      /**
+       * Default configuration values
+       * @property defaults
+       * @type Object
+       * @private
+       * @final
+       */
+      defaults = {
+        buttonTag: "button",
+        on: "click select change",
+        action: "switch",
+        className: "athena-switch"
+      },
+      /**
+       * An array of objects representing available states f
+       * or the switch instance, passed on through the published event.
+       * @property states
+       * @type Array
+       */
+      states = [],
+      /**
+       * The buttons within the Switch container
+       * @property buttons
+       * @type Object
+       */
+      $buttons =[];
      
-     /**
-      * PTClass constructor 
-      * @method initialize
-      * @public
-      * @param {Object} $super Pointer to superclass constructor
-      * @param {Object} $element JQuery object for the element wrapped by the component
-      * @param {Object} settings Configuration settings
-      */    
-     initialize: function ( $super, $element, settings ) {
+      // MIX THE DEFAULTS INTO THE SETTINGS VALUES
+      _.defaults( settings, defaults );
 
-       // PRIVATE INSTANCE PROPERTIES
+      // CALL THE PARENT'S CONSTRUCTOR
+      $super( $element, settings );
+      
+      states = settings.states;
 
-       /**
-        * Instance of Switch
-        * @property Switch
-        * @type Object
-        * @private
-        */     
-       var Switch = this,
+      /**
+       * Sets the state of the switch 
+       * @method toggleState
+       * @public
+       * @param {Object} button The button that was clicked
+       * @return {Object} The Switch instance (for chaining)
+       */
+      Switch.toggleState = function (button) {
+        var $button = $(button),
+        index = $buttons.index($button),
+        state = (states) ? states[index] : null;
+        
+        _.log("Switch.toggleState", button, state);
+        $button.attr(DISABLED, DISABLED);
+        $buttons.not($button).removeAttr(DISABLED);
+        Switch.trigger( settings.action, [  state ] );
+        return Switch;
+      };
+      
+      Switch.init = function () {
+        $buttons = $(settings.buttonTag, $element);
+        $buttons.first().attr(DISABLED, DISABLED); 
+      };
 
-       /**
-        * Default configuration values
-        * @property defaults
-        * @type Object
-        * @private
-        * @final
-        */
-       defaults = {
-         on: 'select change',
-         states: [
-          {
-            state: "OFF",
-            label: "off",
-            className: "athena-switch-off"
-          }, 
-          {
-            state: "ON",
-            label: "on",
-            className: "athena-switch-on"
-          }
-         ]
-       },
-       /**
-        * List of states for the switch
-        * @property states
-        * @type Array
-        * @private
-        */
-       states,
-       i = 0,
-       statesLen,
-       lastState,
-       activeState;
+      Switch.init();
+      Switch.toggleState($buttons.first());
+            
+      $element.on( settings.on, settings.buttonTag, function ( event ) {
+        event.preventDefault();
+        Switch.toggleState(event.target);
+      });
        
-       // MIX THE DEFAULTS INTO THE SETTINGS VALUES
-       _.defaults( settings, defaults );
-   
-       // CALL THE PARENT'S CONSTRUCTOR
-       $super( $element, settings );
-       
-       states = settings.states;
-       statesLen = states.length;
-       activeState = states[i];
-       
-       /**
-        * Sets the state of the switch 
-        * @method toggleState
-        * @public
-        * @return {Object} the Switch instance (for chaining)
-        */       
-       Switch.toggleState = function () {
-         
-         lastState = activeState;
-         
-         // Increment counter
-         ++i;
-
-         // Reset the counter if at the end of the array
-         if ( i === statesLen ) {
-           i = 0;
-         }
-         
-         activeState = states[i];
-         
-         $element.removeClass(lastState.className).addClass(activeState.className);
-         
-         _.log("Switch", "state", activeState);
-         return Switch;
-       };
-              
-       $element.on( settings.on, function ( event ) {
-         event.preventDefault();
-         Switch.toggleState();
-       });
-       
-     }
+    }
   };
-  
 }() ));
 
 //Export to CommonJS Loader

--- a/public/scripts/packages/ui/Container/Switch.js
+++ b/public/scripts/packages/ui/Container/Switch.js
@@ -46,8 +46,7 @@ Switch = Class.create( Container,  ( function () {
       defaults = {
         buttonTag: "button",
         on: "click select change",
-        action: "switch",
-        className: "athena-switch"
+        action: "switch"
       },
       /**
        * An array of objects representing available states f
@@ -75,18 +74,21 @@ Switch = Class.create( Container,  ( function () {
        * Sets the state of the switch 
        * @method toggleState
        * @public
-       * @param {Object} button The button that was clicked
+       * @param {Object} $btn The button that was clicked
        * @return {Object} The Switch instance (for chaining)
        */
-      Switch.toggleState = function (button) {
-        var $button = $(button),
-        index = $buttons.index($button),
-        state = (states) ? states[index] : null;
+      Switch.toggleState = function ($btn) {
+        var index, state;
         
-        _.log("Switch.toggleState", button, state);
-        $button.attr(DISABLED, DISABLED);
-        $buttons.not($button).removeAttr(DISABLED);
-        Switch.trigger( settings.action, [  state ] );
+        if ( $btn.length ) {
+          index = $buttons.index($btn);
+          state = (states) ? states[index] : null;
+          _.log("Switch.toggleState", $btn, state);
+          $btn.attr(DISABLED, DISABLED);
+          $buttons.not($btn).removeAttr(DISABLED);
+          Switch.trigger( settings.action, [  state ] );
+        }
+        
         return Switch;
       };
       
@@ -100,7 +102,19 @@ Switch = Class.create( Container,  ( function () {
             
       $element.on( settings.on, settings.buttonTag, function ( event ) {
         event.preventDefault();
-        Switch.toggleState(event.target);
+        event.stopPropagation();
+        Switch.toggleState( $(event.target) );
+      });
+
+      $element.on( settings.on, function ( event, item ) {
+        event.preventDefault();
+        
+        
+        item = (item > 0) ? item - 1 : 0;
+
+        _.log("YOJIMG", item);
+
+        Switch.toggleState($buttons.eq(item));
       });
        
     }

--- a/public/scripts/packages/ui/Tip.js
+++ b/public/scripts/packages/ui/Tip.js
@@ -173,7 +173,7 @@ Tip =  Class.create( Abstract,  ( function () {
       //MIX THE DEFAULTS INTO THE SETTINGS VALUES
       _.defaults( settings, defaults );
 
-      //Instancetiate the tip
+      //Instantiate the tip
       $tip = $( _.template( settings.template, { content: settings.content } ) );
 
       //transfer the styles from the target to the tip if style is not specified

--- a/public/switch.html
+++ b/public/switch.html
@@ -1,0 +1,59 @@
+<!doctype html>
+
+<!--[if lt IE 7 ]> <html class="no-js ie6" lang="en"> <![endif]-->
+<!--[if IE 7 ]> <html class="no-js ie7" lang="en"> <![endif]-->
+<!--[if IE 8 ]> <html class="no-js ie8" lang="en"> <![endif]-->
+<!--[if (gte IE 9)|!(IE)]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
+
+<head>
+
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+
+  <title>Buttons</title>
+
+  <!-- Feature Detection -->
+  <script src="/scripts/libraries/modernizr-2.0.6.js" type="text/javascript" charset="utf-8"></script>
+
+  <style type="text/css" media="screen">
+    .hidden { display: none; }
+    .athena-switch-on2 { background-color: cyan; }
+    .athena-switch-on { background-color: green; }
+    .athena-switch-off { background-color: red; }
+    
+  </style>
+
+  <!-- Bootstrap:Util -->
+  <script src="/scripts/libraries/underscore.js" type="text/javascript" charset="utf-8"></script>
+  <script src="/scripts/libraries/helpers.js" type="text/javascript" charset="utf-8"></script>
+
+  <!-- Bootstrap:CommonJS Loader -->
+  <script type="text/javascript" src="/scripts/libraries/inject.js"></script>
+
+  <!-- Bootstrap:UI -->
+  <script src="/scripts/libraries/jquery-1.7.js" type="text/javascript" charset="utf-8"></script>
+
+  <script type="text/javascript" charset="utf-8">
+    ATHENA_CONFIG = {
+      debug: true
+    };
+  </script>
+
+  <script type="text/javascript" charset="utf-8">
+    localStorage.clear();
+    require.ensure( ['/scripts/libraries/athena-0.0.1'], function() {} );
+  </script>
+
+</head>
+
+<body>
+
+  <div id="container">
+    <button data-athena="ui:Button:Switch">Switch</button>
+    <button data-athena="ui:Button:MultiSwitch">MultiSwitch</button>
+  </div>
+
+</body>
+
+</html>
+

--- a/public/switch.html
+++ b/public/switch.html
@@ -16,13 +16,22 @@
   <script src="/scripts/libraries/modernizr-2.0.6.js" type="text/javascript" charset="utf-8"></script>
 
   <style type="text/css" media="screen">
-    select.athena-switch,
-    .hidden { display: none; }
-    
-    .athena-switch-on2 { background-color: cyan; }
-    .athena-switch-on { background-color: green; }
-    .athena-switch-off { background-color: red; }
-    
+    .athena-switch { overflow: hidden; *zoom: 1; }
+    .athena-switch button {
+      border: 1px solid #ccc;
+      border-radius: 0 10px 10px 0;
+      font-size: 25px;
+      float: left;
+      margin: 0;
+    }
+    .athena-switch button:first-child {
+      border-radius: 10px 0 0 10px;
+      margin-right: -1px;
+    }
+    .athena-switch button[disabled] {
+      background-color: #000;
+      color: #fff;
+    }
   </style>
 
   <!-- Bootstrap:Util -->
@@ -57,9 +66,30 @@
         states: [{yes: 'i want hamburger'}, {no: 'i want pizza'}]
       } 
     }">
-      <button>hamburger</button>
-      <button>pizza</button>
+      <button>hamburger</button><button>pizza</button>
     </div>
+
+    <button data-athena="ui:Button:Select" data-athena-config="{
+      'ui:Button:Select': {
+        notify: '#switcher',
+        item: 1
+      }
+    }">Select a Burger</button>
+
+    <button data-athena="ui:Button:Select" data-athena-config="{
+      'ui:Button:Select': {
+        notify: '#switcher',
+        item: 2
+      }
+    }">Select Pizza</button>
+
+    <button data-athena="ui:Button:Select" data-athena-config="{
+      'ui:Button:Select': {
+        notify: '#switcher',
+        item: 3
+      }
+    }">This shouldn't work</button>
+
     
   </div>
 

--- a/public/switch.html
+++ b/public/switch.html
@@ -49,8 +49,37 @@
 <body>
 
   <div id="container">
-    <button data-athena="ui:Button:Switch">Switch</button>
-    <button data-athena="ui:Button:MultiSwitch">MultiSwitch</button>
+    
+    <div data-athena="ui:Container:Switch">
+      <button data-athena="ui:Button" data-athena-config="{
+        'ui:Button': {
+          action: 'change'
+        }
+      }">Click Me!</button>
+    </div>
+
+    <div data-athena="ui:Container:Switch" data-athena-config="{
+      'ui:Container:Switch' : {
+        states: [
+          {
+            className: 'athena-switch-off'
+          }, 
+          {
+            className: 'athena-switch-on'
+          },
+          {
+            className: 'athena-switch-on2'
+          }
+        ]
+      }
+    }">
+      <button data-athena="ui:Button" data-athena-config="{
+        'ui:Button': {
+          action: 'change',
+        }
+      }">Multi Click Me!</button>
+    </div>
+    
   </div>
 
 </body>

--- a/public/switch.html
+++ b/public/switch.html
@@ -10,13 +10,15 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 
-  <title>Buttons</title>
+  <title>Switch</title>
 
   <!-- Feature Detection -->
   <script src="/scripts/libraries/modernizr-2.0.6.js" type="text/javascript" charset="utf-8"></script>
 
   <style type="text/css" media="screen">
+    select.athena-switch,
     .hidden { display: none; }
+    
     .athena-switch-on2 { background-color: cyan; }
     .athena-switch-on { background-color: green; }
     .athena-switch-off { background-color: red; }
@@ -50,34 +52,13 @@
 
   <div id="container">
     
-    <div data-athena="ui:Container:Switch">
-      <button data-athena="ui:Button" data-athena-config="{
-        'ui:Button': {
-          action: 'change'
-        }
-      }">Click Me!</button>
-    </div>
-
-    <div data-athena="ui:Container:Switch" data-athena-config="{
-      'ui:Container:Switch' : {
-        states: [
-          {
-            className: 'athena-switch-off'
-          }, 
-          {
-            className: 'athena-switch-on'
-          },
-          {
-            className: 'athena-switch-on2'
-          }
-        ]
-      }
+    <div id="switcher" class="athena-switch" data-athena="ui:Container:Switch" data-athena-config="{
+      'ui:Container:Switch': {
+        states: [{yes: 'i want hamburger'}, {no: 'i want pizza'}]
+      } 
     }">
-      <button data-athena="ui:Button" data-athena-config="{
-        'ui:Button': {
-          action: 'change',
-        }
-      }">Multi Click Me!</button>
+      <button>hamburger</button>
+      <button>pizza</button>
     </div>
     
   </div>


### PR DESCRIPTION
Made changes to athena.js so that now there's a list of Deferred objects.  An unresolved Deferred object is placed into the DeferredList and gets added to the $node's data whenever $node.observe is called.  After Athena is done executing, that Deferred object is marked as resolved(), triggering all the cached notify event-triggers.  Then a fresh Deferred object is pushed onto the DeferredList, becoming available for any later calls to observe().
