### PR TITLE
Quick Config with Examples

### DIFF
--- a/public/examples/carousel-quick.html
+++ b/public/examples/carousel-quick.html
@@ -1,0 +1,92 @@
+<!doctype html>
+
+<!--[if lt IE 7 ]> <html class="no-js ie6" lang="en"> <![endif]-->
+<!--[if IE 7 ]> <html class="no-js ie7" lang="en"> <![endif]-->
+<!--[if IE 8 ]> <html class="no-js ie8" lang="en"> <![endif]-->
+<!--[if (gte IE 9)|!(IE)]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
+
+<head>
+
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+
+  <title>Carousel: Quick Config</title>
+
+  <link rel="shortcut icon" href="/favicon.ico">
+  <link rel="apple-touch-icon" href="/apple-touch-icon.png">
+
+  <!-- Feature Detection -->
+  <script src="/scripts/libraries/modernizr-2.0.6.js" type="text/javascript" charset="utf-8"></script>
+
+  <style type="text/css" media="screen">
+    .athena-selected { font-weight: bold; background-color: red; }
+  </style>
+
+  <!-- Bootstrap:Util -->
+  <script src="/scripts/libraries/underscore.js" type="text/javascript" charset="utf-8"></script>
+  <script src="/scripts/libraries/helpers.js" type="text/javascript" charset="utf-8"></script>
+
+  <!-- Bootstrap:CommonJS Loader -->
+  <script type="text/javascript" src="/scripts/libraries/inject.js"></script>
+
+  <!-- Bootstrap:UI -->
+  <script src="/scripts/libraries/jquery-1.7.js" type="text/javascript" charset="utf-8"></script>
+
+  <script src="/scripts/libraries/athena/config.js" type="text/javascript" charset="utf-8"></script>
+
+  <script type="text/javascript" charset="utf-8">
+    ATHENA_CONFIG = {
+      debug: true
+    };
+  </script>
+
+  <script type="text/javascript" charset="utf-8">
+    localStorage.clear();
+    require.ensure( ['athena'], function() {} );
+  </script>
+
+
+</head>
+
+<h1>Carousel</h1>
+
+<body>
+  
+  
+  <div id="carousel" data-athena="Carousel">
+   
+    <ol id="car-list" class="items">
+      <li class="athena-selected">one</li>
+      <li>two</li>
+      <li>three</li>
+      <li>four</li>
+      <li>five</li>
+    </ol>
+
+    <button id="btn-prev" data-athena="Button:Previous">Previous</button>
+    <button id="btn-next" data-athena="Button:Next">Next</button>
+
+
+  </div>
+
+
+  <div id="carousel2" data-athena="Carousel">
+    <ol id="car-list2" class="items">
+      <li>one</li>
+      <li class="selected">two</li>
+      <li>three</li>
+      <li>four</li>
+      <li>five</li>
+    </ol>
+    <button id="btn-prev2" data-athena="#! Button(action=previous)">Previous</button>
+    <button id="btn-next2" data-athena="#! Button(action=next)">Next</button>
+    <button id="btn-play2" data-athena="#! Button(action=play)">Play</button>
+    <button id="btn-stop2" data-athena="#! Button(action=pause)">Pause</button>
+  </div>
+
+  <button id="btn-next3" data-athena="#! Button(action=next) => #carousel2">Next</button>
+  <button id="btn-next4" data-athena="#! Button(action=next, notify=#carousel2)">Next</button>
+
+</body>
+
+</html>

--- a/public/scripts/libraries/athena/athena.js
+++ b/public/scripts/libraries/athena/athena.js
@@ -62,10 +62,6 @@ Athena = function( settings ) {
     delete window.module;
   }
   
-  Athena.isSimpleConfig = function( str ) {
-    return ( /^#!/ ).test( str );
-  };
-  
   /**
   * extract the simple config from a data-* attribute
   * takes in a string, and returns a detailed object
@@ -234,6 +230,18 @@ Athena = function( settings ) {
       }
     }
   } )();
+  
+  /**
+   * Returns true if the passed in string is set up to use the SimpleConfig via the #! directive
+   * @public
+   * @static
+   * @method isSimpleConfig
+   * @param {String} str The string to test for SimpleConfig directives
+   * @return {Boolean} True if the element matches the SimpleConfig format
+   */
+  Athena.isSimpleConfig = function( str ) {
+    return ( /^#!/ ).test( str );
+  };
 
   /**
    * Returns true if the passed in element is a control an optional key can be used to match a speciffic Control

--- a/public/scripts/libraries/athena/athena.js
+++ b/public/scripts/libraries/athena/athena.js
@@ -63,14 +63,14 @@ Athena = function( settings ) {
   }
   
   /**
-  * extract the simple config from a data-* attribute
+  * parse the simpleconfig from a given node
   * takes in a string, and returns a detailed object
   * @public
   * @static
   * @param {String} the string to extract a configuration from
   * @return {Object}
   */
-  Athena.extractSimpleConfig = ( function() {
+  Athena.parseSimpleConfig = ( function() {
     /*
     Tokenizer - modified to return Tokenizer Class
     Copyright (c) 2007-2008 Ariel Flesler - aflesler(at)gmail(dot)com | http://flesler.blogspot.com
@@ -98,7 +98,7 @@ Athena = function( settings ) {
                             ].join( "" ) ),
         OPTIONS_REGEX     = /\((.+)\)/,
         ESC_TRIM          = function( str ) { return str.replace( /^\s\s*/, '' ).replace( /\s\s*$/, '' ); }
-    return function extractSimpleConfig( text ) {
+    return function parseSimpleConfig( text ) {
       var data = {}
       var subs = [],
           pubs = [],
@@ -292,15 +292,13 @@ Athena = function( settings ) {
   };
 
   /**
-   * Returns an array of all Athena keys on $element
-   * When simpleconfig is used, it will also store the configs for the items
+   * Extract the simple config from an element and save it
    * @public
    * @static
-   * @method getKeys
+   * @method extractSimpleConfig
    * @param {Object} $element a jQuery collection
-   * @return {Array} An array of Athena keys 
    */
-  Athena.getKeys = function( $element ) {
+  Athena.extractSimpleConfig = function( $element ) {
     var attr = $element.attr( ATTR ),
      simpleConfig = null,
      parsedConfig = {},
@@ -309,10 +307,10 @@ Athena = function( settings ) {
     if( Athena.isSimpleConfig( attr ) ) {
       attr = attr.replace(/^#!\s*/, '');
       _.each( attr.split(";"), function( key, index ) {
-        simpleConfig = Athena.extractSimpleConfig( key ) || null;
+        simpleConfig = Athena.parseSimpleConfig( key ) || null;
 
         if( simpleConfig === null ) {
-          return '';
+          return;
         }
         
         parsedConfig[simpleConfig.name] = {
@@ -325,9 +323,21 @@ Athena = function( settings ) {
         
         $element.data( 'athena-simpleconfig', parsedConfig );
       } );
-      return keys;
+
+      $element.data( 'athena-simplekeys', keys );
     }
-    return ( attr || '' ).split( ' ' );
+  };
+
+  /**
+   * Returns an array of all Athena keys on $element
+   * @public
+   * @static
+   * @method getKeys
+   * @param {Object} $element a jQuery collection
+   * @return {Array} An array of Athena keys 
+   */
+  Athena.getKeys = function( $element ) {
+    return $element.data( 'athena-simplekeys' ) || ( $element.attr( ATTR ) || '' ).split(' ');
   };
 
   /**
@@ -422,6 +432,7 @@ Athena = function( settings ) {
         setData( $node, { 'Deferred': $.Deferred() } );
       }
       
+      Athena.extractSimpleConfig( $node );
       controls = Athena.getKeys( $node );
       numberOfControls += controls.length;
 


### PR DESCRIPTION
This is a proposal for the Quick Config syntax, including a Carousel example that contains buttons created using the alternate format. Here's some notes since the last discussion on the topic.
## The #! directive

One of the biggest changes was to maintain compatibility with the existing Athena structure. For this, it made sense to use a common programming convention #! which in non-tech speak translates to "run this". Before accessing the keys, if the #! directive is found, the config will be extracted and stored in `$node.data('athena-simpleconfig')` and can be picked up later during initialization. Keys found through this method are placed into `$node.data('athena-simplekeys')`.
## Notify / Observe

Quick Config has support for simple directives to indicate publish/subscribe actions:

```
This would be the same as Carousel using the "observe" config for "#selector"
Carousel <= #selector

This would be the same as a button "notifying" the "selector" via its config
Button => #selector
```

As an alternative, Quick Config can take simple key/value pairs, which might be a good compromise. Using key/value pairs, the above might look like...

```
Carousel(observe=#selector)
and
Button(notify=#selector)
```
