### PR TITLE
Fixes issues #44, #66

### DIFF
--- a/scripts/lu-controls/Abstract.js
+++ b/scripts/lu-controls/Abstract.js
@@ -122,12 +122,38 @@ Abstract = Class.create( ( function() {
       }
 
       /**
+       * Adds an event, or a string of joined events to the eventStore
+       * @method addEventToStorage
+       * @private
+       * @param {String} event The event(s) to add
+       */
+      function addEventToStorage( event ) {
+        _.each( event.trim().split( /\s+/g ), function( item ) {
+          eventStore[item] = { method: 'on' };
+        } );
+      }
+
+      /**
+       * Removes an event, or a string of joined events from the eventStore
+       * @method removeEventFromStorage
+       * @private
+       * @param {String} event The event(s) to remove
+       */
+      function removeEventFromStorage( event ) {
+        _.each( event.trim().split( /\s+/g ), function( item ) {
+          if ( eventStore[event] ) {
+            delete eventStore[event];
+          }
+        } );
+      }
+
+      /**
        * Creates an event listener for a type
        * @method on
        * @private
        */
       function on() {
-        eventStore[arguments[0]] = { method: 'on' };
+        addEventToStorage(arguments[0]);
         return $element.on.apply( $element, parameters.apply( this, arguments ) );
       }
 
@@ -137,7 +163,7 @@ Abstract = Class.create( ( function() {
        * @private
        */
       function one() {
-        eventStore[arguments[0]] = { method: 'one' };
+        addEventToStorage(arguments[0]);
         return $element.one.apply( $element, parameters.apply( this, arguments ) );
       }
 
@@ -148,7 +174,7 @@ Abstract = Class.create( ( function() {
        */
       function off() {
         var event = arguments[0];
-        unbind( event );
+        removeEventFromStorage( event );
         return $element.off.apply( $element, parameters.apply( this, arguments ) );
       }
 
@@ -162,7 +188,7 @@ Abstract = Class.create( ( function() {
         
         $element.lu( 'notify', event, parameters );
         if( store && store.method === 'one' ) {
-          unbind( event );
+          removeEventFromStorage( event );
         }
         return $element.trigger.call( $element, event, parameters );
       }
@@ -175,18 +201,6 @@ Abstract = Class.create( ( function() {
        */
       function observe( $observer ) {
         $observer.lu( 'observe', $element );
-      }
-
-      /**
-       * Removes an event from storage
-       * @method unbind
-       * @private
-       * @param {String} event The event to remove.
-       */
-      function unbind( event ) {
-        eventStore = _.reject( eventStore, function( item, key ) {
-          return false;
-        } );
       }
 
       // Set up observers and notifiers

--- a/scripts/lu-controls/Abstract.js
+++ b/scripts/lu-controls/Abstract.js
@@ -126,10 +126,11 @@ Abstract = Class.create( ( function() {
        * @method addEventToStorage
        * @private
        * @param {String} event The event(s) to add
+       * @param {String} method The method (ex: 'on', 'one')
        */
-      function addEventToStorage( event ) {
+      function addEventToStorage( event, method ) {
         _.each( event.trim().split( /\s+/g ), function( item ) {
-          eventStore[item] = { method: 'on' };
+          eventStore[item] = { method: method };
         } );
       }
 
@@ -153,7 +154,7 @@ Abstract = Class.create( ( function() {
        * @private
        */
       function on() {
-        addEventToStorage(arguments[0]);
+        addEventToStorage( arguments[0], 'on' );
         return $element.on.apply( $element, parameters.apply( this, arguments ) );
       }
 
@@ -163,7 +164,7 @@ Abstract = Class.create( ( function() {
        * @private
        */
       function one() {
-        addEventToStorage(arguments[0]);
+        addEventToStorage( arguments[0], 'one' );
         return $element.one.apply( $element, parameters.apply( this, arguments ) );
       }
 

--- a/scripts/lu-controls/Carousel.js
+++ b/scripts/lu-controls/Carousel.js
@@ -25,6 +25,8 @@ Carousel =  Class.create( List, ( function() {
     SELECT_EVENT = 'select',
     SELECTED_EVENT = 'selected',
     PREVIOUS_EVENT = 'previous',
+    SHOWN_EVENT = 'shown',
+    HIDDEN_EVENT = 'hidden',
     NEXT_EVENT = 'next',
     OUT_OF_BOUNDS_EVENT = 'out-of-bounds',
     PLAYING_FLAG = 'lu-playing',
@@ -213,10 +215,19 @@ Carousel =  Class.create( List, ( function() {
         event.stopPropagation();
         Carousel.play();
       } );
-      Carousel.on( [PAUSE_EVENT, NEXT_EVENT, PREVIOUS_EVENT, FIRST_EVENT, LAST_EVENT, SELECT_EVENT].join( ' ' ), function( event, item ) {
+
+      Carousel.on( [PAUSE_EVENT, NEXT_EVENT, PREVIOUS_EVENT, FIRST_EVENT, LAST_EVENT, SELECT_EVENT, HIDDEN_EVENT].join( ' ' ), function( event, item ) {
         event.stopPropagation();
         Carousel.pause();
       } );
+
+      Carousel.on( SHOWN_EVENT, function( event ) {
+        event.stopPropagation();
+        if ( settings.autoplay ) {
+          Carousel.play();
+        }
+      });
+
       Carousel.on( OUT_OF_BOUNDS_EVENT + '.' + NEXT_EVENT, function( event ) {
         var controls;
 
@@ -232,6 +243,7 @@ Carousel =  Class.create( List, ( function() {
         } );
 
       } );
+
       Carousel.on( OUT_OF_BOUNDS_EVENT + '.' + PREVIOUS_EVENT, function( event ) {
         var controls;
 
@@ -246,9 +258,11 @@ Carousel =  Class.create( List, ( function() {
           }
         } );
       } );
+
       Carousel.on( PLAYING_EVENT, function( event ) {
         $element.addClass( PLAYING_FLAG ).removeClass( PAUSED_FLAG );
       } );
+
       Carousel.on( PAUSED_EVENT, function( event ) {
         $element.addClass( PAUSED_FLAG ).removeClass( PLAYING_FLAG );
       } );

--- a/test/index.html
+++ b/test/index.html
@@ -10,7 +10,7 @@
   <meta name="author" content="">
 
   <meta name="viewport" content="width=device-width,initial-scale=1, maximum-scale=1">
-  <link rel="stylesheet" href="../styles/css/base.css">
+  <link rel="stylesheet" href="../styles/css/screen.css">
   <link rel="stylesheet" href="qunit/qunit.css">
 
 </head>

--- a/test/unit-tests/carousel.html
+++ b/test/unit-tests/carousel.html
@@ -12,9 +12,22 @@
   <button data-lu="Button:Next">Next</button>
 </div>
 
+<div id="carousel-container" data-lu="Container">
+	<div id="carousel-test-2" data-lu="Carousel">
+	  <ol>
+	    <li class="lu-selected">One</li>
+	    <li>Two</li>
+	    <li>Three</li>
+	  </ol>
+	  <button data-lu="Button:Previous">Previous</button>
+	  <button data-lu="Button:Next">Next</button>
+	</div>
+</div>
+
 <script>
 
 function run() {
+
 	function setup() {
 		this.$carousel = $('#carousel-test');
 		this.carousel = this.$carousel.lu('getControl');
@@ -131,6 +144,36 @@ function run() {
 		equal(this.carousel.index(), this.$last.index(), "Second item is selected");
 		ok(this.$last.hasClass('lu-selected'), '"lu-selected" class added to the last item');
 		ok(!this.$first.hasClass('lu-selected'), '"lu-selected" class removed from the first item');
+	});
+	
+	module('Auto-playing carousel inside a lu-container', {
+		setup: function() {
+			this.$carouselContainer = $('#carousel-container');
+			this.$carousel = $('#carousel-test-2');
+			this.$list = this.$carousel.find('ol');
+
+			this.carouselContainer = this.$carouselContainer.lu('getControl');
+			this.carousel = this.$carousel.lu('getControl');
+		}
+	});
+
+	test('Hiding the container', function() {
+		expect(2);
+
+		this.carouselContainer.hide();
+
+		ok(!this.$carousel.hasClass('lu-playing'), '"lu-playing" class does not exist in carousel');
+		ok(this.$carousel.hasClass('lu-paused'), '"lu-paused" class exists in carousel');
+	});
+
+	test('Showing the container', function() {
+		expect(2);
+
+		this.carouselContainer.hide();
+		this.carouselContainer.show();
+
+		ok(!this.$carousel.hasClass('lu-paused'), '"lu-paused" class does not exist in carousel');
+		ok(this.$carousel.hasClass('lu-playing'), '"lu-playing" class exists in carousel');
 	});
 
 	// TODO: lots more


### PR DESCRIPTION
I made a few modifications to adding/removing events in the event storage, all in `Abstract.js`.  I've verified the fix by running all unit tests, across multiple browsers.

Additionally, for issue #44, it occurs when an auto-playing carousel is inside a lu-container, and if that lu-container is hidden, the carousel must pause.  To fix this, I register both the `hidden` and `shown` event in `Carousel.js`.  

Issue #44 solution depended on issue #66 being solved.
