### PR TITLE
Updating List to properly select list-items from nested-element events

### DIFF
--- a/scripts/lu-controls/Button.js
+++ b/scripts/lu-controls/Button.js
@@ -25,7 +25,8 @@ Button = Switch.extend( function( Switch ){
     PAUSED_STATE = 'paused',
     commandDecorators,
     defaults = {
-      on: 'click'
+      on: 'click',
+      '__params__': [0,1,2]
     };
 
   /**
@@ -362,10 +363,18 @@ Button = Switch.extend( function( Switch ){
      */
     init: function( $element, settings ){
       var Button = this,
-        command = settings.action || ( settings.__params__ ) ? settings.__params__.shift() : undefined,
+        command = settings.action,
         decorators = [];
 
-      settings.action = command;
+      // Determine the appropriate value for 'command'
+      if ( !command ) {
+        if ( settings && settings.__params__ ) {
+          command = settings.__params__.shift();
+        }
+      }
+      else {
+        commmand = undefined;
+      }
 
       Switch.init.call( this, $element, settings );
 

--- a/scripts/lu-controls/List.js
+++ b/scripts/lu-controls/List.js
@@ -10,7 +10,7 @@ var Switch = require( 'lu/Switch' ),
   Container = require( 'lu/Container' ),
   List;
 
-List = Switch.extend( function( Abstract ){
+List = Switch.extend( function( Switch ){
 
   var NEXT_EVENT = 'next',
     LAST_EVENT = 'last',
@@ -122,7 +122,7 @@ List = Switch.extend( function( Abstract ){
 
       _.defaults( settings, defaults );
 
-      Abstract.init.call( this, $element, settings );
+      Switch.init.call( this, $element, settings );
 
       /**
        * Select an item in the list
@@ -135,7 +135,7 @@ List = Switch.extend( function( Abstract ){
       List.select = function( item ){
         var Container,
           $item,
-          $items = this.$items,
+          $items = List.$items,
           controls = 'lu-controls',
           index;
 
@@ -145,8 +145,18 @@ List = Switch.extend( function( Abstract ){
 
         if( typeof item === 'number' ){
           $item = $items.eq( item );
-        } else if ( typeof item === STRING ){
-          $item = $items.filter( item );
+        } else if ( typeof item === STRING ){          
+          $item = $items.filter( function(index){
+            // Is the selected item one of the list elements?
+            if ($items[index] === item) {
+              return true;
+            }
+            // Or is the selected item contained by one of the list elements?
+            else {
+              return ( $.contains($items[index], $(item)[0]) );
+            }
+            return false;
+          } );
         } else if( item instanceof $ ){
           $item = item;
         } else {


### PR DESCRIPTION
Found a bug in List, e.g. for this markup used to build an accordion widget:

``` html
<ul data-lu="List">
  <li>
    <h2><a href="#section-1" data-lu="Button:Select">Section One</a></h2>
    <div id="section-1">lorem ipsum...</div>
  </li>
  <li>
    <h2><a href="#section-2" data-lu="Button:Select">Section Two</a></h2>
    <div id="section-2">lorem ipsum...</div>
  </li>
</ul>
```

The `item` value sent to `List.select()` will be `section-1`, which doesn't correspond to any of the list's elements (`li` tags).  So, I've updated `List.select()` to first compare `item` with its elements, and if nothing matches, to also check to see if `item` is contained within any of the elements.
