### PR TITLE
Fix for sandbox.html infinite loading

### DIFF
--- a/sandbox.html
+++ b/sandbox.html
@@ -82,7 +82,7 @@
 
 <body>
 
-  <div class="carousel lu-state-forward" data-lu="Tip2"></div>
+  <div class="carousel lu-state-forward" data-lu="Tip"></div>
 
   <div class="carousel lu-state-forward" data-lu="Carousel">
 


### PR DESCRIPTION
The existing sandbox.html is not working properly because it's trying to use a control that appears to have been removed: Tip2. Changing the control to "Tip" fixes this problem. Without the change, sandbox.html never completely loads because it gets stuck trying to load Tip2.js... but it never will.
