### PR TITLE
Changes for Viewport carousel

### DIFF
--- a/scripts/components/List.js
+++ b/scripts/components/List.js
@@ -77,7 +77,7 @@ List = Switch.extend( function( base ){
 
         if( settings.items ){
           if( typeof settings.items === 'string' ){
-            $items = $element.children( settings.items );
+            $items = $element.find( settings.items );
           } else {
             $items = settings.items;
           }

--- a/scripts/components/List/decorators/viewport.js
+++ b/scripts/components/List/decorators/viewport.js
@@ -127,8 +127,10 @@ function viewportDecorator(settings) {
     }
 
     self.on(constants.events.SELECTED, function (event, Component) {
-      slideToSelected();
-    });
+      if (mode === "sliding") {
+        slideToSelected();
+      } 
+   });
 
     if (mode === "paging") {
       // In paging mode, the next/previous events will cause scrolling one page at a time

--- a/scripts/components/List/decorators/viewport.js
+++ b/scripts/components/List/decorators/viewport.js
@@ -9,7 +9,7 @@ function viewportDecorator(settings) {
 
   return function (base) {
     var self = this,
-      slidingWindow = this.$element,
+      slidingWindow = settings.viewport.slidingWindow ? $( settings.viewport.slidingWindow ) : this.$element,
       viewportStartIndex = 0,
       // Settings
       pageSize = settings.viewport.pageSize || 1, // number of elements to show in the viewport
@@ -127,9 +127,7 @@ function viewportDecorator(settings) {
     }
 
     self.on(constants.events.SELECTED, function (event, Component) {
-      if (mode === "sliding") {
-        slideToSelected();
-      }
+      slideToSelected();
     });
 
     if (mode === "paging") {


### PR DESCRIPTION
1. Changed List to use find instead of children to allow specifying children non-shallow items.
2. Allowed slidingWindow to be passed to Viewport as config.
3. Changed Viewport to scroll on selected for page mode as well as sliding.
